### PR TITLE
ci: Adding more types to the changelog

### DIFF
--- a/.releaserc.json
+++ b/.releaserc.json
@@ -1,7 +1,29 @@
 {
   "plugins": [
     "@semantic-release/commit-analyzer",
-    "@semantic-release/release-notes-generator",
+    [
+      "@semantic-release/release-notes-generator",
+      {
+        "preset": "angular",
+        "parserOpts": {
+          "noteKeywords": ["BREAKING CHANGE", "BREAKING CHANGES", "BREAKING", "BREAK CHANGE"]
+        },
+        "presetConfig": {
+          "types": [
+            { "type": "feat", "section": "Features" },
+            { "type": "fix", "section": "Bug Fixes" },
+            { "type": "perf", "section": "Performance Improvements" },
+            { "type": "chore", "section": "Others" },
+            { "type": "docs", "section": "Others" },
+            { "type": "style", "section": "Others" },
+            { "type": "refactor", "section": "Others" },
+            { "type": "build", "section": "Others" },
+            { "type": "ci", "section": "Others" },
+            { "type": "test", "section": "Others" }
+          ]
+        }
+      }
+    ],
     [
       "@semantic-release/npm",
       {


### PR DESCRIPTION
https://github.com/semantic-release/release-notes-generator

https://github.com/conventional-changelog/conventional-changelog-config-spec/blob/master/versions/2.0.0/README.md#types